### PR TITLE
feat: add linux/s390x builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,14 @@ LD_FLAGS="-s -w"
 
 .PHONY: docker-build
 docker-build:
-	@docker buildx build --progress plane --platform linux/arm64,linux/amd64 --tag $(REPO):$(IMAGE_TAG) . --build-arg LD_FLAGS=$(LD_FLAGS)
-	@docker buildx build --progress plane --platform linux/arm64,linux/amd64 --tag $(REPO):latest . --build-arg LD_FLAGS=$(LD_FLAGS)
+	@docker buildx build --progress plane --platform linux/arm64,linux/amd64,linux/s390x --tag $(REPO):$(IMAGE_TAG) . --build-arg LD_FLAGS=$(LD_FLAGS)
+	@docker buildx build --progress plane --platform linux/arm64,linux/amd64,linux/s390x --tag $(REPO):latest . --build-arg LD_FLAGS=$(LD_FLAGS)
 
 .PHONY: docker-push
 docker-push:
-	@docker buildx build --progress plane --platform linux/arm64,linux/amd64 --tag $(REPO):$(IMAGE_TAG) . --build-arg LD_FLAGS=$(LD_FLAGS) --push
-	@docker buildx build --progress plane --platform linux/arm64,linux/amd64 --tag $(REPO):latest . --build-arg LD_FLAGS=$(LD_FLAGS) --push
+	@docker buildx build --progress plane --platform linux/arm64,linux/amd64,linux/s390x --tag $(REPO):$(IMAGE_TAG) . --build-arg LD_FLAGS=$(LD_FLAGS) --push
+	@docker buildx build --progress plane --platform linux/arm64,linux/amd64,linux/s390x --tag $(REPO):latest . --build-arg LD_FLAGS=$(LD_FLAGS) --push
 
 .PHONY: docker-push-dev
 docker-push-dev:
-	@docker buildx build --progress plane --platform linux/arm64,linux/amd64 --tag $(REPO):dev . --build-arg LD_FLAGS=$(LD_FLAGS) --push
+	@docker buildx build --progress plane --platform linux/arm64,linux/amd64,linux/s390x --tag $(REPO):dev . --build-arg LD_FLAGS=$(LD_FLAGS) --push


### PR DESCRIPTION
This PR adds builds for `linux/s390x` arch (to use it on zLinux).
There are corresponding PRs open in the `kyverno` and `policy-reporter` repos to add support there as well:
- https://github.com/kyverno/kyverno/pull/3277
- https://github.com/kyverno/policy-reporter/pull/115

I have validated that the images used in Dockerfile are available as `s390x` variant:
- [node:16-alpine](https://hub.docker.com/layers/node/library/node/16-alpine/images/sha256-781980333497135a1041f87e0986a93c1c081f1cd37fa585979e91f7f181dbcd?context=explore)
- [golang:1.17.6](https://hub.docker.com/layers/golang/library/golang/1.17.6/images/sha256-ec67c62f48ddfbca1ccaef18f9b3addccd707e1885fa28702a3954340786fcf6?context=explore)

Signed-off-by: skuethe <56306041+skuethe@users.noreply.github.com>