### PR TITLE
Disable refresh default

### DIFF
--- a/components/selects/RefreshIntervalSelect.vue
+++ b/components/selects/RefreshIntervalSelect.vue
@@ -36,7 +36,7 @@ export default Vue.extend<Data, Methdos, Computed, {}>({
       { text: '5s', value: 5000 },
       { text: '10s', value: 10000 },
       { text: '30s', value: 30000 },
-      { text: '1min', value: 100000 }
+      { text: '1min', value: 60000 }
     ]
   }),
   computed: mapGetters(['refreshInterval']),

--- a/components/selects/RefreshIntervalSelect.vue
+++ b/components/selects/RefreshIntervalSelect.vue
@@ -30,6 +30,8 @@ type Computed = {
 export default Vue.extend<Data, Methdos, Computed, {}>({
   data: () => ({
     intervals: [
+      // 2 ** 31 - 1 is the limit for setInterval
+      { text: '(never)', value: 2 ** 31 - 1 },
       { text: '1s', value: 1000 },
       { text: '5s', value: 5000 },
       { text: '10s', value: 10000 },

--- a/store/index.ts
+++ b/store/index.ts
@@ -10,7 +10,8 @@ type State = {
 
 export const state = (): State => ({
   currentCluster: undefined,
-  refreshInterval: 10000,
+  // 2 ** 31 - 1 is the limit for setInterval
+  refreshInterval: 2 ** 31 - 1,
   displayMode: sessionStorage.getItem('displayMode') as DisplayMode || DisplayMode.LIGHT,
   clusters: [],
   viewsConfig: {


### PR DESCRIPTION
This adds an option to disables refresh (technically, refresh only after ~50 days) and makes it the default option. The motivation is that Policy Reporter UI page becomes unresponsible for 10-20 seconds in Chrome when loading reports from a busy cluster (~1k namespaces, ~30 policies).

It also fixes minute duration. 