### PR TITLE
Set lang="en"

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -50,7 +50,7 @@ export default defineNuxtConfig({
     head: {
       title: 'Policy Reporter UI',
       htmlAttrs: {
-        lang: 'de'
+        lang: 'en'
       },
       meta: [
         { charset: 'utf-8' },


### PR DESCRIPTION
The policy reporter UI is in English but because of `<html lang="de">` Chrome asks if I want to translate the page from German to English.

<img width="347" height="112" alt="Screenshot 2025-08-04 at 09 26 01" src="https://github.com/user-attachments/assets/ad4a352c-abee-4a36-8fdf-d5322e7aa1d2" />

I think this should be `en` because the text is all English
<img width="288" height="51" alt="Screenshot 2025-08-04 at 09 26 12" src="https://github.com/user-attachments/assets/afe2706f-bfcc-4c9b-8863-0803f460086d" />

This is a very small change from `lang="de"` to `lang="en"`