### PR TITLE
feat(ui): init cluster from query

### DIFF
--- a/frontend/app/app.vue
+++ b/frontend/app/app.vue
@@ -6,6 +6,17 @@
 
 <script lang="ts" setup>
 import { cluster } from "~/core/api";
+const { $coreAPI } = useNuxtApp()
+
+const router = useRouter()
+const route = useRoute()
+
+const start = computed(() => route.query.cluster as string || '')
+
+if (start.value) {
+  $coreAPI.setPrefix(start.value)
+  router.push({ name: route.name as string, query: { ...route.query, cluster: undefined }, params: route.params })
+}
 </script>
 
 <style>

--- a/frontend/app/components/form/ClusterSelect.vue
+++ b/frontend/app/components/form/ClusterSelect.vue
@@ -10,23 +10,26 @@
     density="compact"
     prepend-inner-icon="mdi-kubernetes"
     style="min-width: 140px;"
-    @update:model-value="input"
+    @update:model-value="select"
     v-if="clusters.length > 1"
   />
 </template>
 
 <script lang="ts" setup>
 import { useConfigStore } from "~/store/config";
-import type { CoreAPI } from "~/core/api";
 import { cluster } from "~/core/api";
+
+const router = useRouter()
+const route = useRoute()
 
 const store = useConfigStore()
 const { $coreAPI } = useNuxtApp()
 
 const clusters = computed(() => store.clusters.map(c => ({ title: c.name, value: c.slug })))
 
-const input = (slug: string) => {
-  ($coreAPI as CoreAPI).setPrefix(slug)
+const select = (slug: string) => {
+  $coreAPI.setPrefix(slug)
+  router.push({ name: route.name as string, query: { ...route.query, cluster: slug }, params: route.params })
 }
 
 </script>


### PR DESCRIPTION
This pull request improves how the selected cluster is handled and synchronized between the URL and the application state. The changes ensure that the cluster selection is reflected in the URL and that the API prefix is set consistently based on the current cluster.

Cluster selection and routing improvements:

* In `app.vue`, added logic to automatically set the API prefix from the `cluster` query parameter on initial load and then clean up the URL by removing the `cluster` parameter.
* In `ClusterSelect.vue`, updated the handler to both set the API prefix and update the router query parameter when a new cluster is selected, ensuring the UI and URL stay in sync.